### PR TITLE
Add link to latest User Guide on front page

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,6 +43,8 @@ powerful, easy to use, portable, and support reproducibility.</p>
 <a href="http://docker.com">Docker</a> for portable runtime environments.</p>
 <p>CWL is designed to express workflows for data-intensive science, such as
 Bioinformatics, Medical Imaging, Chemistry, Physics, and Astronomy.</p>
+<h2 id="CWL_User_Guide">CWL User Guide</h1>
+<p><a href="http://www.commonwl.org/draft-3/UserGuide.html">User guide for the current stable specification (draft-3)</a>, providing a gentle introduction to writing CWL command line tools and workflows.</p>
 <h2 id="CWL_Specification">CWL Specification</h1><p>The current stable specification is <a href="http://www.commonwl.org/draft-3/">draft 3</a>:</p>
 <p><a href="http://www.commonwl.org/draft-3/">http://www.commonwl.org/draft-3/</a></p>
 <p>Older drafts: <a href="https://github.com/common-workflow-language/common-workflow-language/tree/master/draft-1">draft-1</a>, <a href="http://www.commonwl.org/draft-2/">draft-2</a></p>


### PR DESCRIPTION
The user guide is really the most important piece of information to get new folks on board to test out CWL. Even though probably having stumbled upon the user guide before, I wasn't aware that it existed, and did not find it when I started evaluating CWL for use within NBIS here in Sweden. I thus think it is really important to have a link to it clearly visible in a prominent place on the front page.
